### PR TITLE
Feature/command class execute

### DIFF
--- a/Commands/CAP.cpp
+++ b/Commands/CAP.cpp
@@ -4,18 +4,30 @@ CAP::CAP() {
 	
 }
 
-CAP::CAP(const CAP& other) {
+CAP::CAP(const CAP& other): Command(other) {
 
 }
 
 CAP& CAP::operator=(const CAP& other) {
-
+	if (this == &other)
+		return *this;
+	Command::operator=(other);
+	return *this;
 }
 
 CAP::~CAP() {
 
 }
 
-void CAP::execute() {
-	cout << "CAP COMMAND" << endl;
+/*
+parser:
+	sendMsg(): 파서가 가지고 있는 소켓으로 인자 메시지를 send 해주는 메서드
+
+server:
+	getHostName(): 클라이언트에게 알릴 서버 이름.
+*/
+void CAP::execute(Server& server, Parser& parser) {
+	static_cast<void>(server);
+	parser.sendMsg("CAP * LS :\r\n");
+	// parser.sendMsg(":" + server.getHostName() + " CAP * LS :" + "\r\n");
 }

--- a/Commands/CAP.hpp
+++ b/Commands/CAP.hpp
@@ -9,11 +9,8 @@ class CAP: public Command {
 		CAP();
 		CAP(const CAP& other);
 		CAP& operator=(const CAP& other);
-		~CAP();
-		virtual void execute();
-
-	private:
-		
+		virtual ~CAP();
+		virtual void execute(Server& server, Parser& parser);
 };
 
 #endif

--- a/Commands/Command.cpp
+++ b/Commands/Command.cpp
@@ -4,14 +4,21 @@ Command::Command() {
 	
 }
 
-Command::Command(const Command& other) {
-
+Command::Command(const Command& other): _cmdSource(other._cmdSource) {
+	
 }
 
 Command& Command::operator=(const Command& other) {
-
+	if (this == &other)
+		return *this;
+	this->_cmdSource = other._cmdSource;
+	return *this;
 }
 
 Command::~Command() {
 
+}
+
+void Command::setCmdSource(vector<string>& cmdSource) {
+	this->_cmdSource = cmdSource;
 }

--- a/Commands/Command.hpp
+++ b/Commands/Command.hpp
@@ -2,19 +2,21 @@
 #ifndef COMMAND_HPP
 # define COMMAND_HPP
 
-using namespace std;
-#include <iostream>
+# include "Server.hpp"
+# include <iostream>
 
 class Command {
 	public:
 		Command();
 		Command(const Command& other);
 		Command& operator=(const Command& other);
-		~Command();
-		virtual void execute() = 0;
+		virtual ~Command();
+		virtual void execute(Server& server, Parser& parser) = 0;
+		void setCmdSource(vector<string>& cmdSource);
+		string makeNumericMsg(const string& hostName, const string& number); // Numeric 메시지 생성함수. 아직 미구현
 
-	private:
-		
+	protected:
+		vector<string> _cmdSource;
 };
 
 #endif

--- a/Commands/CommandController.cpp
+++ b/Commands/CommandController.cpp
@@ -2,6 +2,7 @@
 
 CommandController::CommandController() {
 	this->_commands["CAP"] = new CAP();
+	this->_commands["NICK"] = new NICK();
 	this->_commands["USER"] = new USER();
 }
 
@@ -12,6 +13,11 @@ CommandController::~CommandController() {
 	}
 }
 
-Command* CommandController::makeCommand(const string& msg) {
-	return this->_commands[msg];
+Command* CommandController::makeCommand(Parser& parser) {
+	string cmd = parser.get_command();
+	vector<string> cmdSplit = parser.test_split_command(cmd);
+	// for (int i = 0; i < cmdSplit.size(); i++)
+	// 	std::cout << cmdSplit[i] << std::endl;
+	_commands[cmdSplit[0]]->setCmdSource(cmdSplit);
+	return this->_commands[cmdSplit[0]];
 }

--- a/Commands/CommandController.hpp
+++ b/Commands/CommandController.hpp
@@ -2,12 +2,12 @@
 #ifndef COMMANDCONTROLLER_HPP
 # define COMMANDCONTROLLER_HPP
 
-using namespace std;
-
 # include "Command.hpp"
 # include "CAP.hpp"
 # include "USER.hpp"
+# include "NICK.hpp"
 # include "Parser.hpp"
+# include "Server.hpp"
 # include <vector>
 # include <map>
 
@@ -15,9 +15,9 @@ class CommandController {
 	public:
 		CommandController();
 		~CommandController();
-		Command* makeCommand(const string& msg);
+		Command* makeCommand(Parser& parser);
 	private:
-		map<string, Command*> _commands;
+		std::map<string, Command*> _commands;
 };
 
 #endif

--- a/Commands/NICK.cpp
+++ b/Commands/NICK.cpp
@@ -1,0 +1,37 @@
+#include "NICK.hpp"
+
+NICK::NICK() {
+	
+}
+
+NICK::NICK(const NICK& other): Command(other) {
+
+}
+
+NICK& NICK::operator=(const NICK& other) {
+	if (this == &other)
+		return *this;
+	Command::operator=(other);
+	return *this;
+}
+
+NICK::~NICK() {
+
+}
+
+/*
+parser:
+	sendMsg(): 파서가 가지고 있는 소켓으로 인자 메시지를 send 해주는 메서드
+
+server:
+	addNewClient(): 새 클라이언트를 생성해서 server에 추가하는 메서드.
+	findNickName(): 닉네임 확인하기
+*/
+void NICK::execute(Server& server, Parser& parser) {
+	static_cast<void>(server);
+	static_cast<void>(parser);
+	// if (server.findClientByNickName(_cmsSource[1]) == NULL)
+	// 	server.addNewClient(_cmdSource[1], _cmdSource[4]);
+	// else
+	// 	parser.sendMsg("<client> <nick> :Nickname is already in use");
+}

--- a/Commands/NICK.hpp
+++ b/Commands/NICK.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#ifndef NICK_HPP
+# define NICK_HPP
+
+# include "Command.hpp"
+
+class NICK: public Command {
+	public:
+		NICK();
+		NICK(const NICK& other);
+		NICK& operator=(const NICK& other);
+		virtual ~NICK();
+		virtual void execute(Server& server, Parser& parser);
+};
+
+#endif

--- a/Commands/USER.cpp
+++ b/Commands/USER.cpp
@@ -4,18 +4,31 @@ USER::USER() {
 	
 }
 
-USER::USER(const USER& other) {
+USER::USER(const USER& other): Command(other) {
 
 }
 
 USER& USER::operator=(const USER& other) {
-
+	if (this == &other)
+		return *this;
+	Command::operator=(other);
+	return *this;
 }
 
 USER::~USER() {
 
 }
 
-void USER::execute() {
-	cout << "USER COMMAND" << endl;
+/*
+parser:
+	sendMsg(): 파서가 가지고 있는 소켓으로 인자 메시지를 send 해주는 메서드
+
+server:
+	addNewClient(): 새 클라이언트를 생성해서 server에 추가하는 메서드.
+	findNickName(): 닉네임 확인하기
+*/
+void USER::execute(Server& server, Parser& parser) {
+	static_cast<void>(server);
+	parser.sendMsg(":server 001 <client> :Welcome to the <networkname> Network, <nick>[!<user>@<host>]\r\n");
+	// parser.sendMsg(":" + server.getHostName() + " 001 " + server.getClientById(parser.getSocketFd()));
 }

--- a/Commands/USER.hpp
+++ b/Commands/USER.hpp
@@ -9,11 +9,8 @@ class USER: public Command {
 		USER();
 		USER(const USER& other);
 		USER& operator=(const USER& other);
-		~USER();
-		virtual void execute();
-
-	private:
-		
+		virtual ~USER();
+		virtual void execute(Server& server, Parser& parser);
 };
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 CC = c++
 FLAGS = -Wall -Wextra -Werror -MMD -MP -g3 -std=c++98
+
+COMMAND_DIR = Commands
+
 SRCS =	main.cpp \
-		Server.cpp
+		Server.cpp \
+		Parser.cpp \
+		Commands/CommandController.cpp \
+		Commands/Command.cpp \
+		Commands/NICK.cpp \
+		Commands/USER.cpp \
+		Commands/CAP.cpp 
+
 OBJS = $(SRCS:.cpp=.o)
 NAME = ircserv
 
@@ -11,7 +21,7 @@ $(NAME) : $(OBJS)
 	$(CC) $(FLAGS) $(OBJS) -o $(NAME)
 
 %.o : %.cpp
-	$(CC) $(FLAGS) -c $< -o $@
+	$(CC) $(FLAGS) -c $< -o $@ -I. -ICommands
 
 clean :
 	rm -rf $(OBJS)

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -26,6 +26,7 @@ std::vector<std::string>    Parser::split_command()
     std::string     buffer;
     std::istringstream   iss(input);
     std::vector<std::string> ret;
+
     while (std::getline(iss, buffer))
     {
 		if (_buf.find("\r\n") == std::string::npos)
@@ -35,4 +36,21 @@ std::vector<std::string>    Parser::split_command()
 		_buf = _buf.substr(input.find("\r\n") + 2, input.size() - 1);
     }
     return (ret);
+}
+
+std::vector<std::string>    Parser::test_split_command(std::string& cmd) {
+    std::istringstream   iss(cmd.substr(0, cmd.size() - 2));
+	std::string			buffer;
+    std::vector<std::string> res;
+
+    while (!iss.eof())
+    {
+		iss >> buffer;
+		res.push_back(buffer);
+    }
+    return (res);
+}
+
+void Parser::sendMsg(const std::string& msg) {
+	send(this->_socket_fd, msg.c_str(), msg.size(), 0);
 }

--- a/Parser.hpp
+++ b/Parser.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <sstream>
 
+#include <sys/socket.h>
+
 class Parser
 {
     public:
@@ -12,6 +14,8 @@ class Parser
         ~Parser();
         std::string get_command();
         std::vector<std::string>    split_command();
+        std::vector<std::string>    test_split_command(std::string& cmd);	// cmd 한줄을 공백 기준으로 나누는 메서드
+		void 						sendMsg(const std::string& msg);		// 파서가 가지고있는 fd로 메시지 보내는 메서드
     private:
         std::string _buf;
         int         _socket_fd;


### PR DESCRIPTION
1. [Command] CAP, NICK, USER 클래스 추가 및 execute함수 구현
- - 유연한 응답은 없고, 성공했을때를 기준으로 메시지 전달
- - 메시지별로 클라이언트 정보, 서버의 정보, 채널의 정보가 필요하기 때문에 적절한 메서드를 Client, Server, Channel에 구현해야함
- - 커맨드 실행 시 Server 객체와 커맨드의 주인인 Parser객체를 인자로 받을 필요가 있음.

2. [Parser] 명령어 하나를 공백 기준으로 분리하는 test_split_command() 메서드 구현
- - 공백 기준으로 나눈 토큰을 커맨드의 멤버변수로 가지게 함.

3. [Parser] 객체가 가지고 있는 소켓으로 메시지를 보내는 sendMsg() 메서드 구현
- - 해당 메서드를 통해 커맨드 객체가 메시지를 보냄.