### PR TITLE
[refactor] Channel 클래스 멤버 변수 타입 변경

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -10,9 +10,9 @@ Channel::Channel(string empty) : _name(empty)
 	cout << "[INFO][" << _getTimestamp() << "] Error Channel object created.\n";
 }
 
-Channel::Channel(string name, string owner) : _name(name), _inviteOnly(0), _topicOpOnly(1), _user_limit(0)
+Channel::Channel(string name, Client* owner) : _name(name), _inviteOnly(0), _topicOpOnly(1), _user_limit(0)
 {
-	cout << "[INFO][" << _getTimestamp() << "][Channel: " << name << "] Created Successfully by " << owner << ".\n";
+	cout << "[INFO][" << _getTimestamp() << "][Channel: " << name << "] Created Successfully by " << owner->getNickName() << ".\n";
 	join(owner);
 	setOper(owner);
 }
@@ -22,12 +22,12 @@ Channel::~Channel()
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] Channel deleted.\n";
 }
 
-vector<string>	Channel::getUsers() const
+vector<Client*>	Channel::getUsers() const
 {
 	return this->_users;
 }
 
-vector<string>	Channel::getOper() const
+vector<Client*>	Channel::getOper() const
 {
 	return this->_operators;
 }
@@ -48,33 +48,35 @@ string	Channel::getPassword() const
 }
 
 /* */
-int		Channel::isOper(string user) const
+int		Channel::isOper(Client* user) const
 {
-	return _exist(_operators, user);
+	return _exist(_operators, user->getNickName());
 }
 
 /* need oper */
-void	Channel::setOper(string user)
+void	Channel::setOper(Client* user)
 {
-	if (_exist(_operators, user))
-		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " is already has permission.\n";
+	if (!_exist(_users, user->getNickName()))
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is not in the channel.\n";
+	else if (_exist(_operators, user->getNickName()))
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is already has permission.\n";
 	else
 	{
 		_operators.push_back(user);
-		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " is assigned an operator.\n";
+		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is assigned an operator.\n";
 	}
 }
 
 /* need oper */
-void	Channel::removeOper(string user)
+void	Channel::removeOper(Client* user)
 {
 	int idx;
-	if ((idx = _find(_operators, user)) < 0)
-		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user << "is not operator.\n";
+	if ((idx = _find(_operators, user->getNickName())) < 0)
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << "is not operator.\n";
 	else
 	{
 		_operators.erase(_operators.begin() + idx);
-		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] The operator has been removed from the " << user << ".\n"; 
+		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] The operator has been removed from the " << user->getNickName() << ".\n"; 
 	}
 }
 
@@ -92,41 +94,41 @@ void	Channel::removePassword()
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] Password Successfully removed.\n";
 }
 
-void	Channel::join(string user)
+void	Channel::join(Client* user)
 {
-	if (_exist(_users, user))
-		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " is already in the channel.\n";
+	if (_exist(_users, user->getNickName()))
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is already in the channel.\n";
 	else
 	{
 		_users.push_back(user);
-		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " joined the channel.\n";
+		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " joined the channel.\n";
 	}
 }
 
-void	Channel::leave(string user)
+void	Channel::leave(Client* user)
 {
 	int idx;
-	if ((idx = _find(_users, user)) < 0)
-		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user << "is not in the channel.\n";
+	if ((idx = _find(_users, user->getNickName())) < 0)
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << "is not in the channel.\n";
 	else
 	{
 		if (isOper(user))
 			removeOper(user);
 		_users.erase(_users.begin() + idx);
-		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " left the channel.\n"; 
+		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " left the channel.\n"; 
 	}
 }
 
 /* need oper */
-void	Channel::kick(string user)
+void	Channel::kick(Client* user)
 {
 	int idx;
-	if ((idx = _find(_users, user)) < 0)
-		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " is not in the channel.\n";
+	if ((idx = _find(_users, user->getNickName())) < 0)
+		cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is not in the channel.\n";
 	else
 	{
 		_users.erase(_users.begin() + idx);
-		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user << " kicked from the channel.\n";
+		cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " kicked from the channel.\n";
 	}
 }
 
@@ -186,10 +188,10 @@ void	Channel::setMode(CHANNEL_OPT type, int value)
  *  @param	nick : The nickname to search for within the group.
  *  @return The index of the nickname if it exists in the group, otherwise -1.
  **/
-int		Channel::_find(vector<string> group, string nick) const
+int		Channel::_find(vector<Client*> group, string nick) const
 {
 	for (size_t i = 0; i < group.size(); ++i)
-		if (group[i] == nick)
+		if (group[i]->getNickName() == nick)
 			return (i);
 	return (-1);
 }
@@ -200,17 +202,17 @@ int		Channel::_find(vector<string> group, string nick) const
  *  @param	nick : The nickname to search for within the group.
  *  @return 1 if it exists in the group, otherwise 0.
  **/
-int		Channel::_exist(vector<string> group, string nick) const
+int		Channel::_exist(vector<Client*> group, string nick) const
 {
 	for (size_t i = 0; i < group.size(); ++i)
-		if (group[i] == nick)
+		if (group[i]->getNickName() == nick)
 			return (1);
 	return (0);
 }
 
 std::ostream&	operator<<(std::ostream& os, const Channel& ch)
 {
-	vector<string> users = ch.getUsers();
+	vector<Client*> users = ch.getUsers();
 	os << "----------------------------------------------------\n";
 	os << "[INFO][" << ch._getTimestamp() << "][Channel: " << ch.getName() << "] Summary: \n";
 	os << "\t - Channel Mode Settings\n";

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -2,6 +2,7 @@
 # define CHANNEL_HPP
 # include <string>
 # include <vector>
+# include "Client.hpp"
 
 using namespace std;
 
@@ -17,24 +18,24 @@ class Channel
 		} CHANNEL_OPT;
 
 		Channel(string empty);
-		Channel(string name, string owner);
+		Channel(string name, Client* owner);
 		~Channel();
 		
-		vector<string>	getUsers() const;
-		vector<string>	getOper() const;
+		vector<Client*>	getUsers() const;
+		vector<Client*>	getOper() const;
 		string	getName() const;
 		string	getTopic() const;
 		string	getPassword() const;
 
-		int		isOper(string user) const;
+		int		isOper(Client* user) const;
 
-		void	setOper(string user);
-		void	removeOper(string user);
+		void	setOper(Client* user);
+		void	removeOper(Client* user);
 		void	setPassword(string password);
 		void	removePassword();
-		void	join(string user);
-		void	leave(string user);
-		void	kick(string user);
+		void	join(Client* user);
+		void	leave(Client* user);
+		void	kick(Client* user);
 		void	setTopic(string topic);
 
 		int		getMode(CHANNEL_OPT type) const;
@@ -48,16 +49,16 @@ class Channel
 		string	_password;
 		string	_topic;
 
-		vector<string>	_users;
-		vector<string>	_operators;
+		vector<Client*>	_users;
+		vector<Client*>	_operators;
 
 		/* Channel Options */
 		int		_inviteOnly;
 		int		_topicOpOnly;
 		int		_user_limit;
 
-		int		_exist(vector<string> group, string nick) const;
-		int		_find(vector<string> group, string nick) const;
+		int		_exist(vector<Client*> group, string nick) const;
+		int		_find(vector<Client*> group, string nick) const;
 
 };
 std::ostream& operator<<(std::ostream& os, const Channel& ref);

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ COMMAND_DIR = Commands
 SRCS =	main.cpp \
 		Server.cpp \
 		Client.cpp \
+		Channel.cpp \
 		Commands/CommandController.cpp \
 		Commands/Command.cpp \
 		Commands/NICK.cpp \

--- a/Server.cpp
+++ b/Server.cpp
@@ -2,7 +2,7 @@
 #include "Server.hpp"
 #include "Command.hpp"
 
-Server::Server(int port, string password) : _err_client(Client(-1)), _err_channel("EMPTY"), _command_controller(CommandController()), _password(password), _port(port), _socket(-1)
+Server::Server(int port, string password) :  _command_controller(CommandController()),_err_client(Client(-1)), _err_channel("EMPTY"), _password(password), _port(port), _socket(-1)
 {
 	if ((_socket = socket(PF_INET, SOCK_STREAM, 0)) == -1)
 		handle_error("socket error");
@@ -72,17 +72,17 @@ void	Server::run()
 					cout << "bind Client\n";
 					bindClient();
 				}
-				else if (getClient(curr_event->ident).getSocketFd() != -1)
+				else if (getClient(curr_event->ident)->getSocketFd() != -1)
 				{
-					getClient(curr_event->ident).recv();
+					getClient(curr_event->ident)->recv();
 				}
 			}
 			else if (curr_event->filter == EVFILT_WRITE)
 			{
-				Client& cl = getClient(curr_event->ident);
-				Command* cmd = this->_command_controller.makeCommand(cl);
+				Client* cl = getClient(curr_event->ident);
+				Command* cmd = this->_command_controller.makeCommand(*cl);
 				if (cmd != NULL)
-					cmd->execute(*this, cl);
+					cmd->execute(*this, *cl);
 			}
 		}
 	}
@@ -124,7 +124,7 @@ int		Server::bindClient()
 
 int	Server::createChannel(string ch_name, string owner)
 {
-	if (getChannel(ch_name).getName() != "EMPTY")
+	if (getChannel(ch_name)->getName() != "EMPTY")
 	{
 		cout << "[ERROR] Channel " << ch_name << " is already exist.\n";
 		return (0);
@@ -141,42 +141,42 @@ string	Server::getPassword() const
 	return _password;
 }
 
-Client&	Server::getClient(int fd)
+Client*	Server::getClient(int fd)
 {
 	vector<Client>::iterator it = _clients.begin();
 	while (it != _clients.end())
 	{
 		if (fd == (*it).getSocketFd())
-			return (*it);
+			return &(*it);
 		it++;
 	}
 	cout << "cannot find " << fd << " user\n";
 	//throw
-	return _err_client;
+	return NULL;
 }
 
-Client&	Server::getClient(string nick)
+Client*	Server::getClient(string nick)
 {
 	vector<Client>::iterator it = _clients.begin();
 	while (it != _clients.end())	
 	{
 		if (nick == (*it).getNickName())
-			return (*it);
+			return &(*it);
 		it++;
 	}
 	cout << "cannot find " << nick << " user\n";
 	//throw
-	return _err_client;
+	return NULL;
 }
 
-Channel&	Server::getChannel(string ch_name)
+Channel*	Server::getChannel(string ch_name)
 {
 	for (size_t i = 0; i < _channels.size(); ++i)
 	{
 		if (_channels[i].getName() == ch_name)
-			return _channels[i];
+			return &_channels[i];
 	}
-	return _err_channel;
+	return NULL;
 }
 
 // test error -> exception

--- a/Server.hpp
+++ b/Server.hpp
@@ -34,14 +34,14 @@ class Server
 		void	deleteChannel(string ch_name); // *
 		string	getPassword() const; // *
 		
-		Client&		getClient(int fd);
-		Client&		getClient(string nick);
-		Channel&	getChannel(string ch_name);
+		Client*		getClient(int fd);
+		Client*		getClient(string nick);
+		Channel*	getChannel(string ch_name);
 
 
 	private:
 		//error Client(-1)
-    CommandController		_command_controller;
+		CommandController		_command_controller;
 		vector<Channel> _channels;
 		vector<Client>	_clients;
 		Client	_err_client;


### PR DESCRIPTION
## 기존 레퍼런스 저장 형식
- vector<string> _users, _operator 에서
- vector<Client*> _users, _operator로 변경

## Server.cpp
- 채널 관련 메소드나 클라이언트 메소드를 레퍼런스 반환이 아닌 포인터 반환으로 수정

close #26