### PR TITLE
[hotfix] Client 메소드 수정

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -40,12 +40,18 @@ string	Client::getHostName() const
 	return (_host);
 }
 
+string	Client::getUserName() const
+{
+	return (_user);
+}
+
 string	Client::getRealName() const
 {
 	return (_real);
 }
 
-string	Client::getBufName() const
+
+string	Client::getBuf() const
 {
 	return (_buf);
 }

--- a/Client.hpp
+++ b/Client.hpp
@@ -21,8 +21,9 @@ class Client
 
 		string	getNickName() const;
 		string	getHostName() const;
+		string	getUserName() const;
 		string	getRealName() const;
-		string	getBufName() const;
+		string	getBuf() const;
 		int		getSocketFd() const;
 		string	getCommand();
 


### PR DESCRIPTION
- `getUserName()` 중복선언된 메소드 제거
- `getBufName()` -> `getBuf()`로 메소드 이름 수정




close #44 