### PR TITLE
커맨드 컨트롤러의 cmdSplit 함수 수정

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -40,11 +40,6 @@ string	Client::getRealName() const
 	return (_real);
 }
 
-string	Client::getUserName() const
-{
-	return (_user);
-}
-
 string	Client::getBuf() const
 {
 	return (_buf);

--- a/Client.hpp
+++ b/Client.hpp
@@ -23,7 +23,6 @@ class Client
 		string	getUserName() const;
 		string	getHostName() const;
 		string	getRealName() const;
-		string	getUserName() const;
 		string	getBuf() const;
 		int		getSocketFd() const;
 		string	getCommand();

--- a/Commands/CommandController.cpp
+++ b/Commands/CommandController.cpp
@@ -20,15 +20,28 @@ CommandController::~CommandController() {
 	}
 }
 
-vector<string> cmdSplit(string cmd) {
-	istringstream iss(cmd);
+vector<string> CommandController::cmdSplit(string cmd) {
+	string beforeColon;
+	string afterColon;
+	istringstream iss;
 	vector<string> res;
 	string tmp;
 
+	try {
+		beforeColon = cmd.substr(0, cmd.find(":", 0));
+		afterColon = cmd.substr(cmd.find(":", 0));
+		iss.str(beforeColon);
+	} catch (exception& e) {
+		iss.str(cmd);
+	}
 	while (!iss.eof()) {
 		iss >> tmp;
-		res.push_back(tmp);
+		if (tmp != "")
+			res.push_back(tmp);
+		tmp = "";
 	}
+	if (afterColon != "")
+		res.push_back(afterColon);
 	return res;
 }
 
@@ -37,8 +50,8 @@ Command* CommandController::makeCommand(Client& client) {
 	if (cmd == "no_comand")
 		return NULL;
 	vector<string> cmds = cmdSplit(cmd);
-	for (int i = 0; i < static_cast<int>(cmds.size()); i++)
-		cout << cmds[i] << std::endl;
+	// for (int i = 0; i < static_cast<int>(cmds.size()); i++)
+	// 	cout << "[" << i << "]: " << cmds[i] << std::endl;
 	if(_commands[cmds[0]] == NULL)
 		return NULL;
 	_commands[cmds[0]]->setCmdSource(cmds);

--- a/Commands/CommandController.hpp
+++ b/Commands/CommandController.hpp
@@ -14,6 +14,7 @@ class CommandController {
 		Command* makeCommand(Client& parser);
 	private:
 		std::map<string, Command*> _commands;
+		vector<string> cmdSplit(string cmd);
 };
 
 #endif


### PR DESCRIPTION
- 같은 명령어가 두번 들어오는 버그 수정
- ':' 기준으로 이후 토큰을 하나로 보는 로직으로 수정

close #40 
close #43 