### PR TITLE
[Feat] 채널 관련 커맨드 구현

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -161,6 +161,38 @@ void	Channel::broadcast(string msg, Client* except_client)
 	}
 }
 
+void	Channel::invite(string nick)
+{
+	for (size_t i = 0; i < _invites.size(); ++i)
+	{
+		if (_invites[i] == nick)
+			return;
+	}
+	_invites.push_back(nick);
+}
+
+void	Channel::accept(string nick)
+{
+	for (size_t i = 0; i < _invites.size(); ++i)
+	{
+		if (_invites[i] == nick)
+		{
+			_invites.erase(_invites.begin() + i);
+			return ;
+		}
+	}
+	cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << nick << " is not invited.\n";
+}
+
+int Channel::isInvited(string nick)
+{
+	for (size_t i = 0; i < _invites.size(); ++i)
+	{
+		if (_invites[i] == nick)
+			return (1);
+	}
+	return (0);
+}
 
 int	Channel::getMode(CHANNEL_OPT type) const
 {

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -39,6 +39,9 @@ class Channel
 		void	kick(Client* user);
 		void	broadcast(string msg);
 		void	broadcast(string msg, Client* except_client);
+		void	invite(string nick);
+		void	accept(string nick);
+		int		isInvited(string nick);
 
 		int		getMode(CHANNEL_OPT type) const;
 		void	setMode(CHANNEL_OPT type, int value);
@@ -50,6 +53,7 @@ class Channel
 		string	_password;
 		string	_topic;
 
+		vector<string>	_invites;
 		vector<Client*>	_users;
 		vector<Client*>	_operators;
 

--- a/Commands/INVITE.cpp
+++ b/Commands/INVITE.cpp
@@ -1,0 +1,55 @@
+#include "INVITE.hpp"
+
+INVITE::INVITE() {}
+INVITE::~INVITE() {}
+
+void	INVITE::execute(Server& server, Client& client)
+{
+	if (_cmdSource.size() < 3)
+	{
+		client.send(makeNumericMsg(server, client, "461"));
+		return ;
+	}
+
+	string	invitee = _cmdSource[1];
+	string	inviter = client.getNickName();
+	string	ch_name = _cmdSource[2];
+
+	Channel*	ch = server.getChannel(ch_name);
+	if (ch == NULL)
+	{
+		client.send(makeNumericMsg(server, client, ch_name, "403"));
+		return ;
+	}
+
+	vector<Client*> users = ch->getUsers();
+	bool isInviterOnCh = false, isInviterHasOp = false, isInviteOnly = ch->getMode(ch->INVITE_ONLY);
+	for (vector<Client*>::const_iterator it = users.begin(); it != users.end(); ++it)
+	{
+		if ((*it)->getNickName() == inviter)
+		{
+			if ((isInviteOnly && ch->isOper(&client)) || !isInviteOnly)
+				isInviterHasOp = true;
+			isInviterOnCh = true;
+		}
+		if ((*it)->getNickName() == invitee)
+		{
+			client.send(makeNumericMsg(server, client, ch_name, "443"));
+			return;
+		}
+	}
+
+	if (isInviterOnCh && isInviterHasOp)
+	{
+		Client* target = server.getClient(invitee);
+		if (target != NULL)
+			target->send(":" + client.who() + " INVITE " + invitee + " :" + ch_name + "\r\n");
+		ch->invite(invitee);
+		client.send(":" + server.getServername() + " 341 " + inviter + " " + invitee + " " + ch_name + "\r\n");
+		
+	}
+	else if (isInviterOnCh && !isInviterHasOp)
+		client.send(makeNumericMsg(server, client, ch_name, "482"));
+	else
+		client.send(makeNumericMsg(server, client, ch_name, "442"));
+}

--- a/Commands/INVITE.hpp
+++ b/Commands/INVITE.hpp
@@ -1,0 +1,19 @@
+#ifndef INVITE_HPP
+# define INVITE_HPP
+
+# include "Command.hpp"
+# include "Server.hpp"
+# include "Client.hpp"
+# include "Channel.hpp"
+
+# define ERR_NOSUCHCHANNEL "403"
+
+class INVITE: public Command {
+	public:
+		INVITE();
+		~INVITE();
+
+		virtual void execute(Server& server, Client& client);
+};
+
+#endif

--- a/Commands/KICK.cpp
+++ b/Commands/KICK.cpp
@@ -1,0 +1,76 @@
+#include "KICK.hpp"
+#include <iostream>
+#include <sstream>
+
+KICK::KICK()
+{
+
+}
+
+KICK::KICK(const KICK& ref)
+{
+	*this = ref;
+}
+
+KICK::~KICK()
+{
+
+}
+
+KICK&	KICK::operator=(const KICK& ref)
+{
+	if (this == &ref)
+		return *this;
+
+	// nothing can copy it...
+	return *this;
+}
+
+void	KICK::execute(Server& server, Client& client)
+{
+	string	ch_name = this->_cmdSource[1];
+	vector<s_msg> msgs = splitMsg(this->_cmdSource[2], this->_cmdSource[3]);
+	
+	Channel* ch = server.getChannel(ch_name);
+	if (ch == NULL)
+	{
+		client.send(makeNumericMsg(server, client, ch_name, "403"));
+		return;
+	}
+
+	for (vector<s_msg>::iterator it = msgs.begin(); it != msgs.end(); ++it)
+	{
+		if (server.getClient((*it).nick) == NULL)
+		{
+			client.send(makeNumericMsg(server, client, (*it).nick, "401"));
+			continue;
+		}
+		ch->kick(server.getClient((*it).nick));
+		ch->broadcast(":" + client.who() + " KICK " + ch_name + " " +  (*it).nick + " :" + (*it).reason + "\r\n");
+	}
+}
+
+vector<KICK::s_msg>	KICK::splitMsg(string user, string reason)
+{
+	stringstream	ss_user(user);
+	stringstream	ss_reason(reason);
+	vector<s_msg>	result;
+	s_msg			item;
+
+	if (user.find(',') != std::string::npos)
+	{
+		while (getline(ss_user, item.nick, ','))
+		{
+			item.reason = reason;
+			result.push_back(item);
+		}
+	}
+	else
+	{
+		item.nick = user;
+		item.reason = reason;
+		result.push_back(item);
+	}
+	return result;
+}
+

--- a/Commands/KICK.hpp
+++ b/Commands/KICK.hpp
@@ -1,0 +1,30 @@
+#ifndef KICK_HPP
+# define KICK_HPP
+
+# include "Command.hpp"
+# include "Server.hpp"
+# include "Client.hpp"
+# include "Channel.hpp"
+
+# define ERR_NOSUCHCHANNEL "403"
+# define ERR_NOSUCHNICK "401"
+
+class KICK: public Command {
+	public:
+		struct s_msg
+		{
+			string	nick;
+			string	reason;
+		};
+
+		KICK();
+		KICK(const KICK& ref);
+		KICK& operator=(const KICK& ref);
+		~KICK();
+
+		virtual void execute(Server& server, Client& client);
+		vector<string> getMsg(const vector<string>& command);
+		vector<s_msg> splitMsg(string user, string reason);
+};
+
+#endif

--- a/Commands/PART.cpp
+++ b/Commands/PART.cpp
@@ -1,0 +1,31 @@
+#include "PART.hpp"
+
+PART::PART() {}
+PART::~PART() {}
+
+void	PART::execute(Server& server, Client& client)
+{
+	string		ch_name = _cmdSource[1];
+	Channel*	ch = server.getChannel(ch_name);
+
+	if (_cmdSource.size() < 2)
+	{
+		client.send(makeNumericMsg(server, client, "461"));
+		return;
+	}
+	if (ch == NULL)
+	{
+		client.send(makeNumericMsg(server, client, ch_name, "403"));
+		return;
+	}
+	vector<Client*> users = ch->getUsers();
+	for (vector<Client*>::const_iterator it = users.begin(); it != users.end(); ++it)
+	{
+		if ((*it)->getNickName() == client.getNickName())
+		{
+			ch->broadcast(client.who() + " PART " + ch_name + "\r\n");
+			return ;
+		}
+	}
+	client.send(makeNumericMsg(server, client, "442"));
+}

--- a/Commands/PART.hpp
+++ b/Commands/PART.hpp
@@ -1,0 +1,19 @@
+#ifndef PART_HPP
+# define PART_HPP
+
+# include "Command.hpp"
+# include "Server.hpp"
+# include "Client.hpp"
+# include "Channel.hpp"
+
+# define ERR_NOSUCHCHANNEL "403"
+
+class PART: public Command {
+	public:
+		PART();
+		~PART();
+
+		virtual void execute(Server& server, Client& client);
+};
+
+#endif

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -8,21 +8,26 @@ void	TOPIC::execute(Server& server, Client& client)
 {
 	string msg;
 	Channel* ch = server.getChannel(_cmdSource[1]);
-	if (_cmdSource.size() == 2)
-		msg = ch->getName() + " topic is " + ch->getTopic() + ".\r\n"; 
-	else
+	if (ch->getMode(ch->TOPIC_OPER_ONLY) && ch->isOper(&client))
 	{
-		if (_cmdSource[2].length() == 1)
-		{
-			ch->clearTopic();
-			msg = ch->getName() + " topic is cleared\r\n.";
-		}
+		if (_cmdSource.size() == 2)
+			msg = ch->getName() + " topic is " + ch->getTopic() + ".\r\n"; 
 		else
 		{
-			string topic = _cmdSource[2].erase(0);
-			ch->setTopic(topic);
-			msg = ch->getName() + " topic is changed to " + topic + ".\r\n";
+			if (_cmdSource[2].length() == 1)
+			{
+				ch->clearTopic();
+				msg = ch->getName() + " topic is cleared\r\n.";
+			}
+			else
+			{
+				string topic = _cmdSource[2].erase(0);
+				ch->setTopic(topic);
+				msg = ch->getName() + " topic is changed to " + topic + ".\r\n";
+			}
 		}
 	}
+	else
+		msg = makeNumericMsg(server, client, "482");
 	client.send(msg);
 }

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -8,7 +8,7 @@ void	TOPIC::execute(Server& server, Client& client)
 {
 	string msg;
 	Channel* ch = server.getChannel(_cmdSource[1]);
-	if (ch->getMode(ch->TOPIC_OPER_ONLY) && ch->isOper(&client))
+	if ((ch->getMode(ch->TOPIC_OPER_ONLY) && ch->isOper(&client)) || !ch->getMode(ch->TOPIC_OPER_ONLY))
 	{
 		if (_cmdSource.size() == 2)
 			msg = ch->getName() + " topic is " + ch->getTopic() + ".\r\n"; 

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -1,0 +1,28 @@
+#include "TOPIC.hpp"
+
+TOPIC::TOPIC() {}
+TOPIC::TOPIC(const TOPIC& ref) { *this = ref; }
+TOPIC::~TOPIC() {}
+
+void	TOPIC::execute(Server& server, Client& client)
+{
+	string msg;
+	Channel* ch = server.getChannel(_cmdSource[1]);
+	if (_cmdSource.size() == 2)
+		msg = ch->getName() + " topic is " + ch->getTopic() + ".\r\n"; 
+	else
+	{
+		if (_cmdSource[2].length() == 1)
+		{
+			ch->clearTopic();
+			msg = ch->getName() + " topic is cleared\r\n.";
+		}
+		else
+		{
+			string topic = _cmdSource[2].erase(0);
+			ch->setTopic(topic);
+			msg = ch->getName() + " topic is changed to " + topic + ".\r\n";
+		}
+	}
+	client.send(msg);
+}

--- a/Commands/TOPIC.hpp
+++ b/Commands/TOPIC.hpp
@@ -1,0 +1,21 @@
+#ifndef TOPIC_HPP
+# define TOPIC_HPP
+
+# include "Command.hpp"
+# include "Server.hpp"
+# include "Client.hpp"
+# include "Channel.hpp"
+
+# define ERR_NOSUCHCHANNEL "403"
+# define ERR_CHANOPRIVSNEEDED "482"
+
+class TOPIC: public Command {
+	public:
+		TOPIC();
+		TOPIC(const TOPIC& ref);
+		~TOPIC();
+
+		virtual void execute(Server& server, Client& client);
+};
+
+#endif


### PR DESCRIPTION
# KICK
- 특정 채널에서 사용자를 내보내는 기능
- 컴마로 구분된 여러 클라이언트 정보가 들어오는 경우에 `,`를 기반으로 분리해서 각각 채널에 `broadcast()`시킴.

# INVITE
- 사용자가 특정 사용자를 채널로 초대하는 기능.
- 채널의 옵션중 오퍼레이터만 초대 가능이 활성화 되어있다면, 초대한 `inviter`의 권한을 확인하여 작동시키게함.
- 초대가 완료되면 초대된 특정 채널내에 초대 리스트에 추가됨.

# Channel
- INVITE 메소드 구현을 위한 멤버 변수 선언:  `_invites: vector<string>` 클라이언트의 고유 nick을 보관.
- 관련 메소드 추가 구현
    - `invite(string nick)`: 특정 사용자를 초대리스트에 추가
    - `accept(string nick)`: 초대리스트에 포함된 사용자를 확인 및 삭제, 초대되어 있지 않다면 에러.
    - `isInvited(string nick)`: 해당 사용자가 해당 채널에 초대되어있는지 확인.
    
# TOPIC
- 채널 설정이 관리자 권한이 필요없다면 
    - topic 부분이 비어져있다면 토픽 반환
    - `:`이라면 토픽 제거
    - 있다면 토픽 설정
- 관리자 권한 필요하다면 메세지 보낸 사용자의 권한 확인 후 진행

# PART
- 사용자가 채널을 나갔을 때 보내는 메세지
- 사용자가 나가면 해당 채널에 `broadcast`함


close #27