### PR TITLE
[Refactor] 클라이언트 연결 해제

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -53,6 +53,11 @@ int		Channel::isOper(Client* user) const
 	return _exist(_operators, user->getNickName());
 }
 
+int		Channel::checkUserInChannel(string nick) const
+{
+	return _exist(_users, nick);
+}
+
 /* need oper */
 void	Channel::setOper(Client* user)
 {

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -28,6 +28,7 @@ class Channel
 		string	getPassword() const;
 
 		int		isOper(Client* user) const;
+		int		checkUserInChannel(string nick) const;
 		void	setOper(Client* user);
 		void	setPassword(string password);
 		void	setTopic(string topic);

--- a/Server.cpp
+++ b/Server.cpp
@@ -62,7 +62,7 @@ void	Server::run()
 				else
 				{
 					cerr << "client socket error\n";
-					disconnect_client(curr_event->ident, clients);
+					disconnect_client(curr_event->ident);
 				}
 			}
 			else if (curr_event->filter == EVFILT_READ)
@@ -97,11 +97,24 @@ void	Server::change_events(vector<struct kevent>& change_list, uintptr_t ident
 	change_list.push_back(temp_event);
 }
 
-void	Server::disconnect_client(int client_fd, map<int, string>& clients)
+void	Server::disconnect_client(int client_fd)
 {
+	Client* cl = getClient(client_fd);
 	cout << "client disconnected: " << client_fd << endl;
 	close(client_fd);
-	clients.erase(client_fd);
+	for (size_t i = 0; i < _clients.size(); ++i)
+	{
+		if (_clients[i].getSocketFd() == client_fd);
+		{
+			for (size_t j = 0; j < _channels.size(); ++j)
+			{
+				if (_channels[j].checkUserInChannel(cl->getNickName()))
+					_channels[j].leave(cl);
+			}
+			_clients.erase(_clients.begin() + i);
+			return ;
+		}
+	}
 }
 
 int		Server::bindClient()

--- a/Server.cpp
+++ b/Server.cpp
@@ -136,6 +136,15 @@ int		Server::bindClient()
 	return (1);
 }
 
+void	Server::notify(string nick, string msg)
+{
+	for (size_t i = 0; i < _channels.size(); ++i)
+	{
+		if (_channels[i].checkUserInChannel(nick))
+			_channels[i].broadcast(msg);
+	}
+}
+
 int	Server::createChannel(string ch_name, Client* owner)
 {
 	if (getChannel(ch_name) != NULL)

--- a/Server.cpp
+++ b/Server.cpp
@@ -141,7 +141,7 @@ void	Server::notify(string nick, string msg)
 	for (size_t i = 0; i < _channels.size(); ++i)
 	{
 		if (_channels[i].checkUserInChannel(nick))
-			_channels[i].broadcast(msg);
+			_channels[i].broadcast(msg, getClient(nick));
 	}
 }
 

--- a/Server.hpp
+++ b/Server.hpp
@@ -32,6 +32,7 @@ class Server
 
 		int			bindClient();
 		int			createChannel(string ch_name, Client* owner);
+		void		notify(string nick, string msg);
 		void		deleteChannel(string ch_name);
 		string		getPassword() const;
 		string		getServername() const;

--- a/Server.hpp
+++ b/Server.hpp
@@ -26,17 +26,15 @@ class Server
 		Server(int port, string password);
 		~Server();
 
-		void	run();
-		void	change_events(vector<struct kevent>& change_list, uintptr_t ident, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
-		void	disconnect_client(int client_fd, map<int, string>& clients);
+		void		run();
+		void		change_events(vector<struct kevent>& change_list, uintptr_t ident, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
+		void		disconnect_client(int client_fd);
 
-		int		bindClient();
-		int		createChannel(string ch_name, Client* owner);
-
-		void	deleteChannel(string ch_name); // *
-		string	getPassword() const; // *
-		string	getServername() const;
-		
+		int			bindClient();
+		int			createChannel(string ch_name, Client* owner);
+		void		deleteChannel(string ch_name);
+		string		getPassword() const;
+		string		getServername() const;
 		Client*		getClient(int fd);
 		Client*		getClient(string nick);
 		Channel*	getChannel(string ch_name);


### PR DESCRIPTION
# Server
- `disconnect_client(string nick)` 메소드 수정
close #70
    - 불필요한 두번째 인자 삭제 `map<int, string> clients`
    - 해당 유저 삭제 시 유저가 속해있는 모든 채널에서 내보냄.
- `notify(string nick, string msg)`: 클라이언트가 속해있는 모든 채널에 `broadcast` msg를 보냄.
close #64
# Channel
- `checkUserInChannel(string nick)`: 해당 유저가 채널에 있는지 반환.
