### PR TITLE
[Fix] 명령어 발신메세지 수정

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -71,6 +71,11 @@ string	Channel::getTopic() const
 	return this->_topic;
 }
 
+string	Channel::getTopicByWho() const
+{
+	return this->_topicByWho;
+}
+
 string	Channel::getPassword() const
 {
 	return this->_password;
@@ -108,9 +113,10 @@ void	Channel::setPassword(string password)
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] Password Successfully changed to " << password << ".\n";
 }
 
-void	Channel::setTopic(string topic)
+void	Channel::setTopic(string topic, string nick)
 {
 	this->_topic = topic;
+	this->_topicByWho = nick;
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] Channel topic changed to " << topic << ".\n";
 }
 

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -28,13 +28,14 @@ class Channel
 		vector<string> getInvites() const;
 		string	getName() const;
 		string	getTopic() const;
+		string	getTopicByWho() const;
 		string	getPassword() const;
 
 		int		isOper(Client* user) const;
 		int		checkUserInChannel(string nick) const;
 		void	setOper(Client* user);
 		void	setPassword(string password);
-		void	setTopic(string topic);
+		void	setTopic(string topic, string nick);
 		void	clearTopic();
 		void	removeOper(Client* user);
 		void	removePassword();
@@ -56,6 +57,7 @@ class Channel
 		string	_name;
 		string	_password;
 		string	_topic;
+		string	_topicByWho;
 
 		vector<string>	_invites;
 		vector<Client*>	_users;

--- a/Commands/INVITE.cpp
+++ b/Commands/INVITE.cpp
@@ -34,7 +34,7 @@ void	INVITE::execute(Server& server, Client& client)
 		}
 		if ((*it)->getNickName() == invitee)
 		{
-			client.send(":" + server.getServername() + " 443 " + client.getNickName() + " " + invitee + " " + ch->getName() + "\r\n");
+			client.send(":" + server.getServername() + " 443 " + client.getNickName() + " " + invitee + " " + ch->getName() + " :is already on channel\r\n");
 			return;
 		}
 	}

--- a/Commands/KICK.cpp
+++ b/Commands/KICK.cpp
@@ -50,8 +50,8 @@ void	KICK::execute(Server& server, Client& client)
 			client.send(makeNumericMsg(server, client, (*it).nick, "401"));
 			continue;
 		}
-		ch->kick(server.getClient((*it).nick));
 		ch->broadcast(":" + client.who() + " KICK " + ch_name + " " +  (*it).nick + " :" + (*it).reason + "\r\n");
+		ch->kick(server.getClient((*it).nick));
 	}
 }
 

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -33,27 +33,25 @@ void	TOPIC::execute(Server& server, Client& client)
 			if (ch->getTopic().length() == 0)
 				msg += "331 " + client.getNickName() + " " + ch->getName() + " :No topic is set\r\n";
 			else
+			{
 				msg += "332 " + client.getNickName() + " " + ch->getName() + " :" + ch->getTopic() + "\r\n";
+				msg += ":" + server.getServername() + " 333 " + client.getNickName() + " " + ch->getName() + " " + ch->getTopicByWho() + " " + to_string(chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()) + "\r\n";
+			}
 		}
 		else
 		{
 			if (_cmdSource[2].length() == 1)
-			{
 				ch->clearTopic();
-				msg += "332 " + client.getNickName() + " " + ch->getName() + "\r\n";
-			}
 			else
 			{
 				string topic = _cmdSource[2].erase(0, 1);
-				ch->setTopic(topic);
-				msg += "332 " + client.getNickName() + " " + ch->getName() + " :" + ch->getTopic() + "\r\n";
+				ch->setTopic(topic, client.who());
 			}
 
 			vector<Client*> users = ch->getUsers();
 			for (size_t i = 0; i < users.size(); ++i)
 			{
-				users[i]->send(msg);
-				users[i]->send(":" + server.getServername() + " 333 " + users[i]->getNickName() + " " + ch->getName() + " " + client.getNickName() + " " + to_string(chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()) + "\r\n");
+				users[i]->send(":" + client.who() + " TOPIC " + ch->getName() + " :" + ch->getTopic() + "\r\n");
 			}
 		}
 	}


### PR DESCRIPTION
# Channel
- `topicByWho`: 마지막 토픽 변경자 저장
- `setTopic(string topic, string nick)`: 기존 `setTopic(string topic)`에서 추가적으로 변경한 유저를 기록해둠. `who()`형식으로 저장해야함.

#  INVITE
- 이미 사용자가 채널에 속해있는 경우에 보내는 뉴메릭 메세지 수정

# TOPIC
- 토픽 변경 이후 모든 사용자에게 보내는 메세지 형식 변경
close #95 

# KICK
- 기존 잘못된 순서로 인해 킥당한 사용자에게 메세지가 발송되지 않았음. (순서변경)
close #91