### PR TITLE
Feature/command and pass authenticated clients logic #98 #99 #103

### DIFF
--- a/Commands/Command.cpp
+++ b/Commands/Command.cpp
@@ -153,11 +153,10 @@ string Command::get_channel_mode(Channel& channel)
 	return (mode);
 }
 
-
-int Command::checkNotRegisterClient(Server& server, Client& client) {
-	if (client.getNickName() == "*" || client.getUserName() == "" || client.getRealName() == "") {
+bool Command::isRegisterClient(Server& server, Client& client) {
+	if (!client.getVerifyStatus() || client.getNickName() == "*" || client.getUserName() == "" || client.getRealName() == "") {
 		client.send(makeNumericMsg(server, client, ERR_NOTREGISTERED));
-		return 1;
+		return false;
 	}
-	return 0;
+	return true;
 }

--- a/Commands/Command.hpp
+++ b/Commands/Command.hpp
@@ -48,7 +48,7 @@ class Command {
 		void setCmdSource(vector<string>& cmdSource);
 	protected:
 		string  get_channel_mode(Channel& channel);
-		int checkNotRegisterClient(Server& server, Client& client);
+		bool isRegisterClient(Server& server, Client& client);
 		const string makeNumericMsg(Server& server, Client& client, const string& num);
 		const string makeNumericMsg(Server& server, Client& client, const string& name, const string& num);
 		const string makeNumericMsg(Server& server, Client& client, Channel& channel, const string& num);

--- a/Commands/JOIN.cpp
+++ b/Commands/JOIN.cpp
@@ -24,7 +24,7 @@ JOIN::~JOIN() {
 }
 
 void JOIN::execute(Server& server, Client& client) {
-	if (checkNotRegisterClient(server, client))
+	if (!isRegisterClient(server, client))
 		return ;
 	if (this->_cmdSource.size() < 2) {
 		client.send(makeNumericMsg(server, client, ERR_NEEDMOREPARAMS));

--- a/Commands/NICK.cpp
+++ b/Commands/NICK.cpp
@@ -22,6 +22,10 @@ NICK::~NICK() {
 }
 
 void NICK::execute(Server& server, Client& client) {
+	if (!client.getVerifyStatus()) {
+		client.send(makeNumericMsg(server, client, ERR_NOTREGISTERED));
+		return ;
+	}
 	// 파라미터 확인
 	if (this->_cmdSource.size() < 2) {
 		client.send(makeNumericMsg(server, client, ERR_NONICKNAMEGIVEN));

--- a/Commands/NICK.hpp
+++ b/Commands/NICK.hpp
@@ -14,6 +14,7 @@ class NICK: public Command {
 		NICK& operator=(const NICK& other);
 		virtual ~NICK();
 		virtual void execute(Server& server, Client& parser);
+	private:
 		bool	checkNickName(const string& nickName);
 };
 

--- a/Commands/PASS.cpp
+++ b/Commands/PASS.cpp
@@ -13,21 +13,24 @@ PASS& PASS::operator=(const PASS& other) {
 
 void	PASS::execute(Server& server, Client& client)
 {
-	if (client.getNickName() != "*")
-	{
-		client.send(makeNumericMsg(server, client, "462"));
+	if (client.getVerifyStatus())
 		return ;
-	}
 	if (_cmdSource.size() < 2)
 	{
-		client.send(makeNumericMsg(server, client, "461"));
+		client.send(makeNumericMsg(server, client, ERR_NEEDMOREPARAMS));
+		return ;
+	}
+	if (client.getNickName() != "*")
+	{
+		client.send(makeNumericMsg(server, client, ERR_ALREADYREGISTERED));
 		return ;
 	}
 	if (server.getPassword() != _cmdSource[1])
 	{
-		client.send(makeNumericMsg(server, client, "464"));
+		client.send(makeNumericMsg(server, client, ERR_PASSWDMISMATCH));
 		server.disconnect_client(client.getSocketFd());
 		return ;
 	}
+	client.verify();
 	//client.send("PASS: AUTHENTICATE"); -> 필요없음
 }

--- a/Commands/USER.hpp
+++ b/Commands/USER.hpp
@@ -14,6 +14,9 @@ class USER: public Command {
 		USER& operator=(const USER& other);
 		virtual ~USER();
 		virtual void execute(Server& server, Client& parser);
+	private:
+		bool	checkUserName(const string& userName);
+		bool	checkRealName(const string& realName);
 };
 
 #endif


### PR DESCRIPTION
- NICK, USER
    - PASS인증절차 확인 로직 추가

- Command
    - PASS, NICK, USER 인증절차 확인 메서드 `isRegisterClient` 추가

- JOIN
    - 기존에 사용했던 `checkRegisterClient`로직을 `isRegisterClient`로 변경


close #98 
close #99 
close #103 