### PR TITLE
닉네임이 빈 문자열이 들어올 수 있는 경우 처리, 및 JOIN에서 accept 버그 수정

### DIFF
--- a/Commands/Command.cpp
+++ b/Commands/Command.cpp
@@ -29,16 +29,11 @@ const string Command::makeNumericMsg(Server& server, Client& client, const strin
 
 	res += string(":") + server.getServername() + " " + num + " ";
 	if (num == RPL_WELCOME) {
-		// res += client.getNickName() + " :Welcome to the " + server.getHostName() + " NetWork, " + client.getNickName() + "!" + client.getUserName() + "@" + server.getHostName() + "\r\n";
-		res += client.getNickName() + " :Welcome to the " + "server" + " NetWork, " + client.getNickName() + "!" + client.getUserName() + "@" + client.getHostName();
+		res += client.getNickName() + " :Welcome to the " + server.getServername() + " NetWork, " + client.who();
 	} else if (num == ERR_NOTEXTTOSEND) {
 		res += client.getNickName() + " " + ":No text to send";
 	} else if (num == ERR_NONICKNAMEGIVEN) {
 		res += client.getNickName() + " " + ":No nickname given";
-	} else if (num == ERR_ERRONEUSNICKNAME) {
-		res += client.getNickName() + " " + this->_cmdSource[1] + " " + ":Erroneus nickname" + "\r\n";
-	} else if (num == ERR_NICKNAMEINUSE) {
-		res += client.getNickName() + " " + this->_cmdSource[1] + " " + ":Nickname is already in use" + "\r\n";
 	} else if (num == ERR_NEEDMOREPARAMS) {
 		res += client.getNickName() + " " + this->_cmdSource[0] + " " + ":Not enough parameters";
 	} else if (num == ERR_ALREADYREGISTERED) {
@@ -47,8 +42,6 @@ const string Command::makeNumericMsg(Server& server, Client& client, const strin
 		res += client.getNickName() + " " + ":You have not registered";
 	} else if (num == ERR_PASSWDMISMATCH) {
 		res += client.getNickName() + " " + ":Password incorrect";
-	} else if (num == ERR_UNKNOWNCOMMAND) {
-		res += client.getNickName() + " " + this->_cmdSource[0] + " " + ":Unknown command";
 	} else {
 		return "";
 	}
@@ -75,6 +68,12 @@ const string Command::makeNumericMsg(Server& server, Client& client, const strin
 		res += name + " " + ":Bad Channel Mask";
 	} else if (num == ERR_NOTONCHANNEL) {
 		res += client.getNickName() + " " + name + " :You're not on that channel";
+	} else if (num == ERR_ERRONEUSNICKNAME) {
+		res += client.getNickName() + " " + name + " " + ":Erroneus nickname" + "\r\n";
+	} else if (num == ERR_NICKNAMEINUSE) {
+		res += client.getNickName() + " " + name + " " + ":Nickname is already in use" + "\r\n";
+	} else if (num == ERR_UNKNOWNCOMMAND) {
+		res += client.getNickName() + " " + name + " " + ":Unknown command";
 	} else {
 		return "";
 	}

--- a/Commands/JOIN.cpp
+++ b/Commands/JOIN.cpp
@@ -62,10 +62,10 @@ void JOIN::execute(Server& server, Client& client) {
 		}
 		// 초대 전용 모드이고 초대되지 않았을 경우
 		if (channel->getMode(Channel::INVITE_ONLY) && !channel->isInvited(client.getNickName())) {
-			channel->accept(client.getNickName());
 			client.send(makeNumericMsg(server, client, *channel, ERR_INVITEONLYCHAN));
 			continue;
-		}
+		} else if (channel->getMode(Channel::INVITE_ONLY) && channel->isInvited(client.getNickName()))
+			channel->accept(client.getNickName());
 		if (!newChannel)
 			channel->join(&client);
 		channel->broadcast(":" + client.getNickName() + "!~" + client.getUserName() + "@" + client.getHostName() + " " + "JOIN" + " " + channelName + "\r\n");

--- a/Commands/UNKNOWN.cpp
+++ b/Commands/UNKNOWN.cpp
@@ -22,5 +22,5 @@ UNKNOWN::~UNKNOWN() {
 }
 
 void UNKNOWN::execute(Server& server, Client& client) {
-	client.send(makeNumericMsg(server, client, ERR_UNKNOWNCOMMAND));
+	client.send(makeNumericMsg(server, client, this->_cmdSource[0], ERR_UNKNOWNCOMMAND));
 }


### PR DESCRIPTION
### NICK
---
닉네임에 ':'로 공백 또는 빈문자열이 들어올 경우 처리

### JOIN
---
accept 조건을 제대로 변경함

### Command - makeNumericMsg
---
_cmdSource 필드를 직접 사용하는 부분을, 인자로 받게 변경

close #114 
close #115 
