### PR TITLE
[Refactor] Server 내 Client, Channel 저장 방식 수정

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -17,7 +17,16 @@ Channel::Channel(string name, Client* owner) : _name(name), _inviteOnly(0), _top
 
 Channel::Channel(const Channel& ref)
 {
-	*this = ref;
+	this->_name = ref._name;
+	this->_inviteOnly = ref._inviteOnly;
+	this->_topicOpOnly = ref._topicOpOnly;
+	this->_topicByWho = ref._topicByWho;
+	this->_user_limit = ref._user_limit;
+	this->_topic = ref._topic;
+	this->_password = ref._password;
+	this->_users = ref._users;  // 벡터를 통째로 복사
+	this->_operators = ref._operators;  // 벡터를 통째로 복사
+	this->_invites = ref._invites;  // 벡터를 통째로 복사
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << ref._name << "] Created Successfully inside vector.\n";
 }
 
@@ -39,10 +48,9 @@ Channel&	Channel::operator=(const Channel& ref)
 	this->_user_limit = ref._user_limit;
 	this->_topic = ref._topic;
 	this->_password = ref._password;
-	for (size_t i = 0; i < ref._users.size(); ++i)
-		this->_users.push_back(ref._users[i]);
-	for (size_t i = 0; i < ref._operators.size(); ++i)
-		this->_operators.push_back(ref._operators[i]);
+	this->_users = ref._users;
+	this->_operators = ref._operators;
+	this->_invites = ref._invites;
 	return *this;
 }
 

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -208,7 +208,7 @@ void	Channel::broadcast(string msg, Client* except_client)
 {
 	for (vector<Client*>::const_iterator it = _users.begin(); it != _users.end(); ++it)
 	{
-		if (except_client != *it)
+		if (except_client->getNickName() != (*it)->getNickName())
 			(*it)->send(msg);
 	}
 }

--- a/Client.cpp
+++ b/Client.cpp
@@ -8,9 +8,15 @@ Client::Client(int fd, string client_addr) : _nick("*"), _host(client_addr), _fd
 {
 }
 
-Client::Client(const Client& ref) : _nick(ref._nick), _host(ref._host), _fd(ref._fd), _isVerified(ref._isVerified)
+Client::Client(const Client& ref)
 {
-	*this = ref;
+	_nick = ref._nick;
+	_fd = ref._fd;
+	_user = ref._user;
+	_host = ref._host;
+	_real = ref._real;
+	_buf = ref._buf;
+	_isVerified = ref._isVerified;
 }
 
 Client&	Client::operator=(const Client& ref)
@@ -30,7 +36,7 @@ Client&	Client::operator=(const Client& ref)
 
 Client::~Client()
 {
-
+	
 }
 
 string	Client::who() const
@@ -128,7 +134,7 @@ int		Client::recv()
 	{
 		if (n < 0)
 		{
-			cerr << _fd << "client read error\n";
+			cout << "[ERROR][" << Server::_getTimestamp() << "] RECV ERROR by " << _fd << "th fd.\n"; 
 			return (0);
 		}
 	}

--- a/Commands/INVITE.cpp
+++ b/Commands/INVITE.cpp
@@ -44,6 +44,11 @@ void	INVITE::execute(Server& server, Client& client)
 		Client* target = server.getClient(invitee);
 		if (target != NULL)
 			target->send(":" + client.who() + " INVITE " + invitee + " :" + ch_name + "\r\n");
+		else
+		{
+			client.send(makeNumericMsg(server, client, invitee, ERR_NOSUCHNICK));
+			return ;
+		}
 		ch->invite(invitee);
 		client.send(":" + server.getServername() + " 341 " + inviter + " " + invitee + " " + ch_name + "\r\n");
 		

--- a/Server.hpp
+++ b/Server.hpp
@@ -45,9 +45,9 @@ class Server
 
 	private:
 		//error Client(-1)
-		CommandController		_command_controller;
-		vector<Channel> _channels;
-		vector<Client>	_clients;
+		CommandController	_command_controller;
+		vector<Channel*>	_channels;
+		vector<Client*>		_clients;
 		string	_password;
 		string	_name;
 		int		_port;


### PR DESCRIPTION
# Server
-  기존 레퍼런스 저장 방식을 삭제
- 동적 할당한 객체를 저장하는 방식으로 수정
- `createChannel`, `deleteChannel`, `bindClient`, `disconnect_client` 관련 메소드 수정
close #116 

# Invite
- 초대 대상이 존재하는지 확인하는 에외처리 추가

# Channel, Client
- 기존 복사생성자에서 벡터 할당하는 부분을 벡터 깊은 복사로 변경
- `disconnect_client`내 유저가 해당 채널을 나갈 때 비게되면 삭제하는 로직 추가
close #113 