### PR TITLE
QUIT 구현

### DIFF
--- a/Commands/CommandController.cpp
+++ b/Commands/CommandController.cpp
@@ -10,6 +10,7 @@
 #include "TOPIC.hpp"
 #include "INVITE.hpp"
 #include "PART.hpp"
+#include "QUIT.hpp"
 #include "UNKNOWN.hpp"
 #include <sstream>
 #include <iostream>
@@ -26,6 +27,7 @@ CommandController::CommandController() {
 	this->_commands["INVITE"] = new INVITE();
 	this->_commands["TOPIC"] = new TOPIC();
 	this->_commands["PART"] = new PART();
+	this->_commands["QUIT"] = new QUIT();
 	this->_commands["UNKNOWN"] = new UNKNOWN();
 }
 

--- a/Commands/QUIT.cpp
+++ b/Commands/QUIT.cpp
@@ -1,0 +1,31 @@
+#include "QUIT.hpp"
+
+QUIT::QUIT() {
+	
+}
+
+QUIT::QUIT(const QUIT& other): Command(other) {
+
+}
+
+QUIT& QUIT::operator=(const QUIT& other) {
+	if (this == &other)
+		return *this;
+	Command::operator=(other);
+	return *this;
+}
+
+QUIT::~QUIT() {
+
+}
+// 당장 보내는 메시지를 이게 전부인것으로 파악됨
+// :yeondcho!~w@118.218.39.69 QUIT :Client Quit
+// 
+void QUIT::execute(Server& server, Client& client) {
+	string command;
+
+	command = this->_cmdSource[0];
+	server.notify(client.getNickName(), ":" + client.who() + " " + command + " " + ":Client Quit" + "\r\n");
+	client.send(":" + client.who() + " " + command + " " + ":Client Quit" + "\r\n");
+	server.disconnect_client(client.getSocketFd());
+}

--- a/Commands/QUIT.hpp
+++ b/Commands/QUIT.hpp
@@ -1,0 +1,17 @@
+#ifndef QUIT_HPP
+# define QUIT_HPP
+
+# include "Command.hpp"
+# include "Server.hpp"
+# include "Client.hpp"
+
+class QUIT: public Command {
+	public:
+		QUIT();
+		QUIT(const QUIT& other);
+		QUIT& operator=(const QUIT& other);
+		virtual ~QUIT();
+		virtual void execute(Server& server, Client& parser);
+};
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ SRCS =	main.cpp \
 		Commands/TOPIC.cpp \
 		Commands/KICK.cpp \
 		Commands/INVITE.cpp \
-		Commands/PART.cpp 
+		Commands/PART.cpp \
+		Commands/QUIT.cpp 
 
 OBJS = $(SRCS:.cpp=.o)
 NAME = ircserv


### PR DESCRIPTION
- 자잘한 사항이 많기 때문에 클라이언트 측 연결 해제만 구현함.
- QUIT이 아닌 경우에도 채널에 관련 메시지를 보내야 하는데 이는 별도로 구현이 필요해보임

close #119 