### PR TITLE
[Fix] 버그 수정

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -325,6 +325,7 @@ std::ostream&	operator<<(std::ostream& os, const Channel& ch)
 	os << "----------------------------------------------------\n";
 	os << "[INFO][" << ch._getTimestamp() << "][Channel: " << ch.getName() << "] Summary: \n";
 	os << "\t - Channel Mode Settings\n";
+	os << "\t\t [Password] : " << ch.getPassword() << "\n";
 	os << "\t\t [EDIT TOPIC PERMISSION] : " << (ch.getMode(ch.TOPIC_OPER_ONLY) ? "Operator" : "User") << "\n";
 	os << "\t\t [INVITE ONLY] : " << (ch.getMode(ch.INVITE_ONLY) ? "true" : "false") << "\n";
 	os << "\t\t [USER LIMIT] : " << ch.getMode(ch.USER_LIMIT) << "\n";

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -84,6 +84,11 @@ string	Channel::getTopicByWho() const
 	return this->_topicByWho;
 }
 
+string	Channel::getTopicChangedTime() const
+{
+	return this->_topicChangedTime;
+}
+
 string	Channel::getPassword() const
 {
 	return this->_password;
@@ -127,6 +132,7 @@ void	Channel::setTopic(string topic, string nick)
 		topic = topic.erase(0, 1);
 	this->_topic = topic;
 	this->_topicByWho = nick;
+	this->_topicChangedTime = to_string(chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count());
 	cout << "[INFO][" << _getTimestamp() << "][Channel: " << _name << "] Channel topic changed to " << topic << ".\n";
 }
 

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -29,6 +29,7 @@ class Channel
 		string	getName() const;
 		string	getTopic() const;
 		string	getTopicByWho() const;
+		string	getTopicChangedTime() const;
 		string	getPassword() const;
 
 		int		isOper(Client* user) const;
@@ -58,6 +59,7 @@ class Channel
 		string	_password;
 		string	_topic;
 		string	_topicByWho;
+		string	_topicChangedTime;
 
 		vector<string>	_invites;
 		vector<Client*>	_users;

--- a/Commands/KICK.cpp
+++ b/Commands/KICK.cpp
@@ -52,6 +52,8 @@ void	KICK::execute(Server& server, Client& client)
 		}
 		ch->broadcast(":" + client.who() + " KICK " + ch_name + " " +  (*it).nick + " :" + (*it).reason + "\r\n");
 		ch->kick(server.getClient((*it).nick));
+		if (ch->getUsers().size() == 0)
+			server.deleteChannel(ch->getName());
 	}
 }
 

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -1,8 +1,5 @@
 #include "TOPIC.hpp"
 
-#include <chrono>
-#include <iostream>
-
 TOPIC::TOPIC() {}
 TOPIC::TOPIC(const TOPIC& ref) { *this = ref; }
 TOPIC::~TOPIC() {}
@@ -35,7 +32,7 @@ void	TOPIC::execute(Server& server, Client& client)
 			else
 			{
 				msg += "332 " + client.getNickName() + " " + ch->getName() + " :" + ch->getTopic() + "\r\n";
-				msg += ":" + server.getServername() + " 333 " + client.getNickName() + " " + ch->getName() + " " + ch->getTopicByWho() + " " + to_string(chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()) + "\r\n";
+				msg += ":" + server.getServername() + " 333 " + client.getNickName() + " " + ch->getName() + " " + ch->getTopicByWho() + " " + ch->getTopicChangedTime() + "\r\n";
 			}
 		}
 		else

--- a/Server.cpp
+++ b/Server.cpp
@@ -226,7 +226,7 @@ void	Server::deleteChannel(string ch_name)
 		if (_channels[i]->getName() == ch_name)
 		{
 			_channels.erase(_channels.begin() + i);
-			return ;
+			break ;
 		}
 	}
 	delete ch;

--- a/Server.cpp
+++ b/Server.cpp
@@ -59,7 +59,7 @@ void	Server::run()
 		{
 			curr_event = &_event_list[i];
 
-			if (curr_event->flags & (EV_ERROR))
+			if (curr_event->flags & EV_ERROR)
 			{
 				if ((int)curr_event->ident == _socket)
 				{
@@ -73,18 +73,14 @@ void	Server::run()
 				}
 			}
 			else if (curr_event->ident == STDIN_FILENO)
-			{
 				debugger();
-			}
 			else if (curr_event->filter == EVFILT_READ)
 			{
 				if ((int)curr_event->ident == _socket)
 					bindClient();
-				else if (getClient(curr_event->ident)->getSocketFd() != -1)
-				{
-					if (!getClient(curr_event->ident)->recv())
+				else if (getClient(curr_event->ident) != NULL)
+					if (!getClient(curr_event->ident)->recv() || curr_event->flags & EV_EOF)
 						disconnect_client(curr_event->ident);
-				}
 			}
 			else if (curr_event->filter == EVFILT_WRITE)
 			{


### PR DESCRIPTION
# Server
## EV_EOF | EV_ERROR
- 기존 EV_EOF와 EV_ERROR 동시에 처리하는 로직에서
- EV_EOF에 대해서 EV_READ와 동시에 이벤트가 발생하기에 READ 이후에 EOF 확인하고 `disconnect_client`
## EV_READ
- 해당 소켓을 확인하는게 아닌 해당 fd로 된 클라이언트 객체 널가드 수정
close #125 

# Topic / Channel
- topic을 수정하는 시간을 저장해서 뉴메릭 메세지 발송시 반영하도록 수정함
- `getTopicChangedTime`
- `setTopic` 내 변경시간 반영

# Kick
- 유저들이 해당 채널에서 킥 될 때 마다 잔여인원 확인해서 삭제 시키도록 함.
close #124