### PR TITLE
[Fix] Channel 초대인자 변경

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -64,7 +64,7 @@ vector<Client*>	Channel::getOper() const
 	return this->_operators;
 }
 
-vector<string>	Channel::getInvites() const
+vector<Client*>	Channel::getInvites() const
 {
 	return this->_invites;
 }
@@ -219,34 +219,34 @@ void	Channel::broadcast(string msg, Client* except_client)
 	}
 }
 
-void	Channel::invite(string nick)
+void	Channel::invite(Client* user)
 {
 	for (size_t i = 0; i < _invites.size(); ++i)
 	{
-		if (_invites[i] == nick)
+		if (_invites[i]->getNickName() == user->getNickName())
 			return;
 	}
-	_invites.push_back(nick);
+	_invites.push_back(user);
 }
 
-void	Channel::accept(string nick)
+void	Channel::accept(Client* user)
 {
 	for (size_t i = 0; i < _invites.size(); ++i)
 	{
-		if (_invites[i] == nick)
+		if (_invites[i]->getNickName() == user->getNickName())
 		{
 			_invites.erase(_invites.begin() + i);
 			return ;
 		}
 	}
-	cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << nick << " is not invited.\n";
+	cout << "[ERROR][" << _getTimestamp() << "][Channel: " << _name << "] " << user->getNickName() << " is not invited.\n";
 }
 
 int Channel::isInvited(string nick)
 {
 	for (size_t i = 0; i < _invites.size(); ++i)
 	{
-		if (_invites[i] == nick)
+		if (_invites[i]->getNickName() == nick)
 			return (1);
 	}
 	return (0);
@@ -321,7 +321,7 @@ int		Channel::_exist(vector<Client*> group, string nick) const
 std::ostream&	operator<<(std::ostream& os, const Channel& ch)
 {
 	vector<Client*> users = ch.getUsers();
-	vector<string> invites = ch.getInvites();
+	vector<Client*> invites = ch.getInvites();
 	os << "----------------------------------------------------\n";
 	os << "[INFO][" << ch._getTimestamp() << "][Channel: " << ch.getName() << "] Summary: \n";
 	os << "\t - Channel Mode Settings\n";
@@ -337,7 +337,7 @@ std::ostream&	operator<<(std::ostream& os, const Channel& ch)
 	os << "\t - Current Invites (" << invites.size() << "):\n";
 	for (size_t i = 0; i < invites.size(); ++i)
 	{
-		os << "\t\t [" << i + 1 << "] Name: " << invites[i] << "\n";
+		os << "\t\t [" << i + 1 << "] Name: " << invites[i]->getNickName() << "\n";
 	}
 	os << "----------------------------------------------------\n";
 	return os;

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -25,7 +25,7 @@ class Channel
 		
 		vector<Client*>	getUsers() const;
 		vector<Client*>	getOper() const;
-		vector<string> getInvites() const;
+		vector<Client*> getInvites() const;
 		string	getName() const;
 		string	getTopic() const;
 		string	getTopicByWho() const;
@@ -45,8 +45,8 @@ class Channel
 		void	kick(Client* user);
 		void	broadcast(string msg);
 		void	broadcast(string msg, Client* except_client);
-		void	invite(string nick);
-		void	accept(string nick);
+		void	invite(Client* user);
+		void	accept(Client* user);
 		int		isInvited(string nick);
 
 		int		getMode(CHANNEL_OPT type) const;
@@ -61,7 +61,7 @@ class Channel
 		string	_topicByWho;
 		string	_topicChangedTime;
 
-		vector<string>	_invites;
+		vector<Client*>	_invites;
 		vector<Client*>	_users;
 		vector<Client*>	_operators;
 

--- a/Commands/INVITE.cpp
+++ b/Commands/INVITE.cpp
@@ -51,7 +51,7 @@ void	INVITE::execute(Server& server, Client& client)
 			client.send(makeNumericMsg(server, client, invitee, ERR_NOSUCHNICK));
 			return ;
 		}
-		ch->invite(invitee);
+		ch->invite(target);
 		client.send(":" + server.getServername() + " 341 " + inviter + " " + invitee + " " + ch_name + "\r\n");
 		
 	}

--- a/Commands/JOIN.cpp
+++ b/Commands/JOIN.cpp
@@ -65,7 +65,7 @@ void JOIN::execute(Server& server, Client& client) {
 			client.send(makeNumericMsg(server, client, *channel, ERR_INVITEONLYCHAN));
 			continue;
 		} else if (channel->getMode(Channel::INVITE_ONLY) && channel->isInvited(client.getNickName()))
-			channel->accept(client.getNickName());
+			channel->accept(&client);
 
 		if (!newChannel)
 			channel->join(&client);

--- a/Server.cpp
+++ b/Server.cpp
@@ -164,6 +164,8 @@ void	Server::disconnect_client(int client_fd)
 					if (_channels[j]->getUsers().size() == 0)
 						deleteChannel(_channels[j]->getName());
 				}
+				if (_channels[j]->isInvited(cl->getNickName()))
+					_channels[j]->accept(cl);
 			}
 			_clients.erase(_clients.begin() + i);
 			break;


### PR DESCRIPTION
# Channel
- `_invites: vector<string>` -> `vector<Client*>` 변경.
- 변경된 메소드
    - `getInvites()`: 기존 `vector<string>` 형식에서 `vector<Client*>`로 변경.
    - `invite(Client* user)`: 기존 `string nick`에서 Client 객체로 변경
    - `accept(Client* user`: 기존 `string nick`에서 Client 객체로 변경
    - `isInvited()`: 내부 유저 검증로직 수정
    - `ostream`내 초대리스트 출력문 수정 
close #131

# Command
- INVITE, JOIN : 메소드 인자형식 변경됨으로 인해 전달하는 인자 수정

# Server
- `disconnect_client()` 내부에서 해당 유저가 초대되어있는 목록에서 제거시킴.