### PR TITLE
[Hotfix] 디버그 메세지 수정 및 Topic 로직 수정

### DIFF
--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -39,7 +39,7 @@ void	TOPIC::execute(Server& server, Client& client)
 		}
 		else
 		{
-			if (_cmdSource[2].length() == 1)
+			if (_cmdSource[2].length() == 0)
 				ch->clearTopic();
 			else
 			{

--- a/Server.hpp
+++ b/Server.hpp
@@ -44,6 +44,7 @@ class Server
 		Channel*	getChannel(string ch_name);
 
 		static string	_getTimestamp();
+		void	handle_error(string err);
 
 	private:
 		//error Client(-1)
@@ -62,6 +63,5 @@ class Server
 
 };
 
-void	handle_error(string err);
 
 #endif


### PR DESCRIPTION
#  Server
- 치명적 오류에 관한 디버깅 메세지 수정
- `handle_error`: 기존 클래스 외부에 있던 메소드를 내부로 이동함.

# Topic
- `/topic -delete`의 경우 `TOPIC #CH_NAME :` 로 들어오는데 파싱과정에서 콜론을 제거해서 인지하지 못함. 길이검증을 수정함.
close #147 