### PR TITLE
Bugfix/parsing bugfix #151 #152

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -138,8 +138,6 @@ void	Channel::setPassword(string password)
 
 void	Channel::setTopic(string topic, string nick)
 {
-	if (topic.find(":") == 0)
-		topic = topic.erase(0, 1);
 	this->_topic = topic;
 	this->_topicByWho = nick;
 	this->_topicChangedTime = to_string(chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count());

--- a/Client.cpp
+++ b/Client.cpp
@@ -78,18 +78,15 @@ string	Client::getBuf() const
 
 string	Client::getCommand()
 {
-	string			input(_buf);
-	string			buffer;
-	string			line;
-	string			command;
-	istringstream	iss(input);
+	string buffer;
+	size_t crlf_pos;
 
-	if (_buf.find("\r\n") == string::npos)
-		return ("no_comand");
-	getline(iss, buffer);
-	buffer = buffer.substr(0, input.find("\r\n"));
-	_buf = _buf.substr(input.find("\r\n") + 2, input.size() - 1);
-	return (buffer);
+	crlf_pos = _buf.find("\r\n");
+	if (crlf_pos == string::npos)
+		return "";
+	buffer = _buf.substr(0, crlf_pos);
+	_buf = _buf.substr(crlf_pos + 2);
+	return buffer;
 }
 
 void		Client::setNickName(string nick)
@@ -141,9 +138,10 @@ int		Client::recv()
 	else
 	{
 		buf[n] = 0;
+		cout << "[INFO][" << Server::_getTimestamp() << "] RECV1: " << buf << " by " << _fd << "th fd.\n"; 
 		_buf += buf;
 		buf[n - 2] = 0;
-		cout << "[INFO][" << Server::_getTimestamp() << "] RECV: " << buf << " by " << _fd << "th fd.\n"; 
+		cout << "[INFO][" << Server::_getTimestamp() << "] RECV2: " << buf << " by " << _fd << "th fd.\n"; 
 	}
 	return (1);
 }

--- a/Client.cpp
+++ b/Client.cpp
@@ -153,7 +153,6 @@ int		Client::send(const string& msg) const
 		cerr << "client write error\n";
 		return (0);
 	}
-	cout << "[INFO][" << Server::_getTimestamp() << "] SNED: " << msg.substr(0, msg.size() - 2) << " by " << _fd << "th fd.\n"; 
 	return (1);
 }
 

--- a/Client.cpp
+++ b/Client.cpp
@@ -138,10 +138,9 @@ int		Client::recv()
 	else
 	{
 		buf[n] = 0;
-		cout << "[INFO][" << Server::_getTimestamp() << "] RECV1: " << buf << " by " << _fd << "th fd.\n"; 
 		_buf += buf;
 		buf[n - 2] = 0;
-		cout << "[INFO][" << Server::_getTimestamp() << "] RECV2: " << buf << " by " << _fd << "th fd.\n"; 
+		cout << "[INFO][" << Server::_getTimestamp() << "] RECV: " << buf << " by " << _fd << "th fd.\n"; 
 	}
 	return (1);
 }
@@ -154,6 +153,7 @@ int		Client::send(const string& msg) const
 		cerr << "client write error\n";
 		return (0);
 	}
+	cout << "[INFO][" << Server::_getTimestamp() << "] SNED: " << msg.substr(0, msg.size() - 2) << " by " << _fd << "th fd.\n"; 
 	return (1);
 }
 

--- a/Commands/CommandController.cpp
+++ b/Commands/CommandController.cpp
@@ -39,42 +39,41 @@ CommandController::~CommandController() {
 }
 
 vector<string> CommandController::cmdSplit(string cmd) {
+	vector<string> res;
+	istringstream iss;
 	string beforeColon;
 	string afterColon;
-	istringstream iss;
-	vector<string> res;
 	string tmp;
+	size_t colon_pos;
 
-	try {
-		beforeColon = cmd.substr(0, cmd.find(":", 0));
-		afterColon = cmd.substr(cmd.find(":", 0));
-		afterColon = afterColon.substr(1, afterColon.size() - 1);
+	colon_pos = cmd.find(":", 0);
+	if (colon_pos != string::npos) {
+		beforeColon = cmd.substr(0, colon_pos);
+		afterColon = cmd.substr(colon_pos);
+		afterColon = afterColon.substr(1);
 		iss.str(beforeColon);
-	} catch (exception& e) {
-		beforeColon = "";
-		afterColon = "";
+	} else
 		iss.str(cmd);
-	}
 	while (!iss.eof()) {
 		iss >> tmp;
 		if (tmp != "")
 			res.push_back(tmp);
 		tmp = "";
 	}
-	if (afterColon != "")
+	if (colon_pos != string::npos)
 		res.push_back(afterColon);
 	return res;
 }
 
 Command* CommandController::makeCommand(Client& client) {
 	string cmd = client.getCommand();
-	if (cmd == "no_comand")
+	if (cmd == "")
 		return NULL;
 	vector<string> cmds = cmdSplit(cmd);
 	if (cmds.empty())
 		return NULL;
-	// for (int i = 0; i < static_cast<int>(cmds.size()); i++)
-	// 	cout << "[" << i << "]: " << cmds[i] << std::endl;
+	for (int i = 0; i < static_cast<int>(cmds.size()); i++)
+		cout << "[" << i << "]: " << cmds[i] << std::endl;
 	Command* command = this->_commands[cmds[0]];
 	if(command == NULL)
 		command = this->_commands["UNKNOWN"];

--- a/Commands/CommandController.cpp
+++ b/Commands/CommandController.cpp
@@ -44,10 +44,18 @@ vector<string> CommandController::cmdSplit(string cmd) {
 	string beforeColon;
 	string afterColon;
 	string tmp;
-	size_t colon_pos;
+	size_t colon_pos = 0;
+	bool flag = false;
 
-	colon_pos = cmd.find(":", 0);
-	if (colon_pos != string::npos) {
+	for (colon_pos = 0; colon_pos < cmd.size(); colon_pos++) {
+		if (!flag && cmd[colon_pos] == ':')
+			break ;
+		if (cmd[colon_pos] == '#')
+			flag = true;
+		if (cmd[colon_pos] == ' ')
+			flag = false;
+	}
+	if (colon_pos < cmd.size()) {
 		beforeColon = cmd.substr(0, colon_pos);
 		afterColon = cmd.substr(colon_pos);
 		afterColon = afterColon.substr(1);
@@ -55,12 +63,13 @@ vector<string> CommandController::cmdSplit(string cmd) {
 	} else
 		iss.str(cmd);
 	while (!iss.eof()) {
+		// getline(iss, tmp, ' ');
 		iss >> tmp;
 		if (tmp != "")
 			res.push_back(tmp);
 		tmp = "";
 	}
-	if (colon_pos != string::npos)
+	if (colon_pos != cmd.size())
 		res.push_back(afterColon);
 	return res;
 }

--- a/Commands/JOIN.cpp
+++ b/Commands/JOIN.cpp
@@ -117,7 +117,7 @@ void JOIN::scaleTarget() {
 
 bool JOIN::checkValidChannelName(const string& name) {
 	string invalidChar("\x20\x07\x2C");
-	if (name[0] != '#')
+	if (name.empty() || name[0] != '#')
 		return false;
 	for (string::const_iterator it = name.begin(); it != name.end(); it++)
 		if (invalidChar.find(*it) != string::npos)

--- a/Commands/NICK.cpp
+++ b/Commands/NICK.cpp
@@ -34,8 +34,6 @@ void NICK::execute(Server& server, Client& client) {
 	}
 	command = this->_cmdSource[0];
 	nickName = this->_cmdSource[1];
-	if (nickName[0] == ':')
-		nickName = nickName.substr(1, nickName.size() - 1);
 	// 닉네임이 비어있을 때
 	if (nickName.empty()) {
 		client.send(makeNumericMsg(server, client, ERR_NONICKNAMEGIVEN));

--- a/Commands/TOPIC.cpp
+++ b/Commands/TOPIC.cpp
@@ -36,6 +36,7 @@ void	TOPIC::execute(Server& server, Client& client)
 				msg += "332 " + client.getNickName() + " " + ch->getName() + " :" + ch->getTopic() + "\r\n";
 				msg += ":" + server.getServername() + " 333 " + client.getNickName() + " " + ch->getName() + " " + ch->getTopicByWho() + " " + ch->getTopicChangedTime() + "\r\n";
 			}
+			client.send(msg);
 		}
 		else
 		{
@@ -45,7 +46,6 @@ void	TOPIC::execute(Server& server, Client& client)
 			{
 				ch->setTopic(_cmdSource[2], client.who());
 			}
-
 			vector<Client*> users = ch->getUsers();
 			for (size_t i = 0; i < users.size(); ++i)
 			{

--- a/Commands/USER.cpp
+++ b/Commands/USER.cpp
@@ -51,6 +51,8 @@ void USER::execute(Server& server, Client& client) {
 }
 
 bool	USER::checkUserName(const string& userName) {
+	if (userName.empty())
+		return false;
 	for (string::const_iterator it = userName.begin() + 1; it != userName.end(); it++)
 		if (!isalnum(*it))
 			return false;
@@ -59,6 +61,8 @@ bool	USER::checkUserName(const string& userName) {
 
 bool	USER::checkRealName(const string& realName) {
 	string allowChar(": ");
+	if (realName.empty())
+		return false;
 	for (string::const_iterator it = realName.begin() + 1; it != realName.end(); it++)
 		if (!isalnum(*it) && allowChar.find(*it) == string::npos)
 			return false;

--- a/Server.cpp
+++ b/Server.cpp
@@ -130,7 +130,15 @@ void	Server::debugger()
 		{
 			for (vector<Client*>::const_iterator it = _clients.begin(); it != _clients.end(); ++it)
 			{
-				cout << (*it);
+				cout << *(*it);
+			}
+		}
+		else if (cmd == "showallc")
+		{
+			for (vector<Channel*>::const_iterator it = _channels.begin(); it != _channels.end(); ++it)
+			{
+			
+				cout << *(*it);
 			}
 		}
 		else


### PR DESCRIPTION
### Parsing
---
- '#'문자 이후는 채널이름으로 인식하는 로직 추가
- cmdSplit 메서드에서 ':' 문자 뒤로 제대로 파싱되지 않는 버그 수정

### Server
---
- 모든 채널 현황 디버거 추가, 기존 모든 유저 현환 디버거 수정
- 불필요한 로그 출력물 제거

### Client
---
- getCommand 메서드 리팩토링

### Channel
---
- 토픽을 설정하는 메서드에서 토픽 문자를 변경하는 부분 제거

### USER
---
- userName, realName이 빈 문자열인지 확인하는 조건문 추가

### TOPIC
---
- 토픽 RPL 메시지를 생성만 하고 보내지 않는 버그 수정

### NICK
---
- nickName에 ':'문자가 들어갔는지 체크하는 부분 제거

### JOIN
---
- 채널 이름이 빈 문자열이 들어올 수 있기 때문에 처리 조건문 추가 





close #151 
close #152 
